### PR TITLE
pinned resumable-hash layer to x86 since we're using that runtime

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -269,7 +269,7 @@ function build_resumable_hash_layer() {
 
   mkdir ./dist
   # build a docker image that builds the resumable-hash library and package to resumable-hash-lambda-layer.zip
-  docker build -t ${name} .
+  docker build -t ${name} . --platform=linux/amd64
 
   # create a container so we can copy the zip package to local host
   local id=$(docker create ${name})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The lambda runtime is set to be x86, when building the code on an arm machine docker compiles the code for arm architecture. This change sets the container as linux/amd64 to match the lambda runtime for the resumable-hash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
